### PR TITLE
Update postBuild

### DIFF
--- a/methodshub.qmd
+++ b/methodshub.qmd
@@ -1,4 +1,5 @@
 ---
+engine: knitr
 format:
   html:
     embed-resources: true

--- a/postBuild
+++ b/postBuild
@@ -62,7 +62,7 @@ echo
 echo Completed installation of python packages
 echo
 
-PAPERWIZARD_JS="$(R -q -e 'cat(system.file("js", package="paperwizard"))')"
+PAPERWIZARD_JS="$(Rscript -e 'cat(system.file("js", package="paperwizard"))')"
 echo "paperwizard js dir: $PAPERWIZARD_JS"
 
 cd "$PAPERWIZARD_JS"


### PR DESCRIPTION
During Binder builds, R -q -e prints interactive prompt text into stdout, which corrupted the PAPERWIZARD_JS path and caused cd to fail. As a result, npm ci was executed in the wrong directory and could not find package-lock.json. This change uses Rscript -e instead, which outputs only the path and allows the JS dependencies to be installed correctly.

Error message when building: 

cd: $'> cat(system.file("js", package="paperwizard"))\n/srv/rlibs/paperwizard/js> ': No such file or directory